### PR TITLE
Feature/validation logic

### DIFF
--- a/combineSignUp/combineSignUp.xcodeproj/project.pbxproj
+++ b/combineSignUp/combineSignUp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		D023F859243001A30015AFFD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D023F858243001A30015AFFD /* Assets.xcassets */; };
 		D023F85C243001A30015AFFD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D023F85B243001A30015AFFD /* Preview Assets.xcassets */; };
 		D023F85F243001A30015AFFD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D023F85D243001A30015AFFD /* LaunchScreen.storyboard */; };
+		D023F86D2430C67F0015AFFD /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D023F86C2430C67F0015AFFD /* SignUpViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +25,7 @@
 		D023F85B243001A30015AFFD /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		D023F85E243001A30015AFFD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D023F860243001A30015AFFD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D023F86C2430C67F0015AFFD /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +113,7 @@
 		D023F86B243021860015AFFD /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				D023F86C2430C67F0015AFFD /* SignUpViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -188,6 +191,7 @@
 			files = (
 				D023F8532430019B0015AFFD /* AppDelegate.swift in Sources */,
 				D023F8552430019B0015AFFD /* SceneDelegate.swift in Sources */,
+				D023F86D2430C67F0015AFFD /* SignUpViewModel.swift in Sources */,
 				D023F8572430019B0015AFFD /* SignUpView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/combineSignUp/combineSignUp/Source/View/SignUpView.swift
+++ b/combineSignUp/combineSignUp/Source/View/SignUpView.swift
@@ -9,55 +9,49 @@ import SwiftUI
 
 struct SignUpView: View {
 
-    //@State private var username = ""
-    @State private var password = ""
-    @State private var passwordAgain = ""
-    
     @ObservedObject private var viewModel = SignUpViewModel()
 
-    let mockedCondition = Bool.random()
-
     var body: some View {
-        VStack{
+        VStack {
             HStack {
                 Image("LaunchScreen").resizable().aspectRatio(contentMode: .fit)
-                    .frame(width: 80, height: 80).cornerRadius(15)
+                    .frame(width: 65, height: 65).cornerRadius(15)
                     .overlay(
                         RoundedRectangle(cornerRadius: 15)
                             .foregroundColor(.gray)
                             .opacity(0.2)
                 )
                 Text("Crea tu cuenta")
-                    .font(.system(.largeTitle, design: .rounded)).bold()
+                    .font(.system(.body, design: .rounded)).bold()
             }
-            .padding(.top)
+            //.padding(.top)
             
             ScrollView {
                 TextFieldView(fieldName: "Nombre de Usuario", fieldValue: $viewModel.username)
-                    .padding(.top)
+                    //.padding(.top)
                 ValidationView(
                     formText: "Son necesarios al menos 6 caracteres",
                     conditionChecked: $viewModel.isValidUsername)
 
-                HStack{
+                HStack {
                     VStack{
-                        TextFieldView(fieldName: "Contraseña", fieldValue: $password, isSecure: true)
-//                        ValidationView(
-//                            formText: "8+ caracteres",
-//                            conditionChecked: mockedCondition)
-//                        ValidationView(
-//                            formText: "1+ mayúscula",
-//                            conditionChecked: !mockedCondition)
-//                        ValidationView(
-//                            formText: "1+ minúscula",
-//                            conditionChecked: mockedCondition)
+                        TextFieldView(fieldName: "Contraseña", fieldValue: $viewModel.password, isSecure: true)
+                        ValidationView(
+                            formText: "8+ caracteres",
+                            conditionChecked: $viewModel.isValidPasswordLength)
+                        ValidationView(
+                            formText: "1+ mayúscula",
+                            conditionChecked: $viewModel.isValidPasswordUpperCaseLetter)
+                        ValidationView(
+                            formText: "1+ minúscula",
+                            conditionChecked: $viewModel.isValidPasswordLowerCaseLetter)
                         Spacer()
                     }
-                    VStack{
-                        TextFieldView(fieldName: "Repetir", fieldValue: $passwordAgain, isSecure: true)
-//                        ValidationView(
-//                            formText: "Deben coincidir",
-//                            conditionChecked: mockedCondition)
+                    VStack {
+                        TextFieldView(fieldName: "Repetir", fieldValue: $viewModel.passwordAgain, isSecure: true)
+                        ValidationView(
+                            formText: "Deben coincidir",
+                            conditionChecked: $viewModel.areMatchingPasswords)
                         Spacer()
                     }
                 }
@@ -76,19 +70,20 @@ struct SignUpView: View {
                         .cornerRadius(8)
                 }
                 
-                HStack{
+                HStack {
                     Text("¿Tienes una cuenta?")
-                        .font(.system(.body, design: .rounded))
-                        .bold()
+                        .font(.system(.body, design: .rounded)).bold()
+                        .foregroundColor(.secondary)
                     Button(action: {
                         //TODO: to login
                     }){
                         Text("Entra ahora")
-                            .font(.system(.headline))
+                            .font(.system(.headline, design: .rounded))
                             .foregroundColor(.purple)
                     }
                 }.padding()
-            }.padding()
+            }.padding(.horizontal)
+            Spacer()
         }
     }
 }
@@ -101,11 +96,11 @@ struct TextFieldView: View {
     
     var body: some View{
         VStack{
-            if isSecure{
+            if isSecure {
                 SecureField(fieldName, text: $fieldValue)
                     .font(.system(size: 22, weight: .bold, design: .rounded))
                     .padding(.horizontal)
-            }else{
+            } else {
                 TextField(fieldName, text: $fieldValue)
                     .font(.system(size: 22, weight: .bold, design: .rounded))
                     .padding(.horizontal)
@@ -124,7 +119,7 @@ struct ValidationView: View {
     var formText = ""
     @Binding var conditionChecked: Bool
 
-    var body: some View{
+    var body: some View {
         HStack{
             Image(systemName: conditionChecked ? "checkmark.circle" : "xmark.circle")
                 .foregroundColor(conditionChecked ? .blue : .pink)

--- a/combineSignUp/combineSignUp/Source/View/SignUpView.swift
+++ b/combineSignUp/combineSignUp/Source/View/SignUpView.swift
@@ -9,9 +9,11 @@ import SwiftUI
 
 struct SignUpView: View {
 
-    @State private var username = ""
+    //@State private var username = ""
     @State private var password = ""
     @State private var passwordAgain = ""
+    
+    @ObservedObject private var viewModel = SignUpViewModel()
 
     let mockedCondition = Bool.random()
 
@@ -31,31 +33,31 @@ struct SignUpView: View {
             .padding(.top)
             
             ScrollView {
-                TextFieldView(fieldName: "Nombre de Usuario", fieldValue: $username)
+                TextFieldView(fieldName: "Nombre de Usuario", fieldValue: $viewModel.username)
                     .padding(.top)
                 ValidationView(
                     formText: "Son necesarios al menos 6 caracteres",
-                    conditionChecked: mockedCondition)
+                    conditionChecked: $viewModel.isValidUsername)
 
                 HStack{
                     VStack{
                         TextFieldView(fieldName: "Contraseña", fieldValue: $password, isSecure: true)
-                        ValidationView(
-                            formText: "8+ caracteres",
-                            conditionChecked: mockedCondition)
-                        ValidationView(
-                            formText: "1+ mayúscula",
-                            conditionChecked: !mockedCondition)
-                        ValidationView(
-                            formText: "1+ minúscula",
-                            conditionChecked: mockedCondition)
+//                        ValidationView(
+//                            formText: "8+ caracteres",
+//                            conditionChecked: mockedCondition)
+//                        ValidationView(
+//                            formText: "1+ mayúscula",
+//                            conditionChecked: !mockedCondition)
+//                        ValidationView(
+//                            formText: "1+ minúscula",
+//                            conditionChecked: mockedCondition)
                         Spacer()
                     }
                     VStack{
                         TextFieldView(fieldName: "Repetir", fieldValue: $passwordAgain, isSecure: true)
-                        ValidationView(
-                            formText: "Deben coincidir",
-                            conditionChecked: mockedCondition)
+//                        ValidationView(
+//                            formText: "Deben coincidir",
+//                            conditionChecked: mockedCondition)
                         Spacer()
                     }
                 }
@@ -120,7 +122,7 @@ struct TextFieldView: View {
 struct ValidationView: View {
     
     var formText = ""
-    var conditionChecked = false
+    @Binding var conditionChecked: Bool
 
     var body: some View{
         HStack{

--- a/combineSignUp/combineSignUp/Source/View/SignUpView.swift
+++ b/combineSignUp/combineSignUp/Source/View/SignUpView.swift
@@ -22,35 +22,35 @@ struct SignUpView: View {
                             .opacity(0.2)
                 )
                 Text("Crea tu cuenta")
-                    .font(.system(.body, design: .rounded)).bold()
+                    .font(.system(.largeTitle, design: .rounded)).bold()
             }
-            //.padding(.top)
+            .padding(.top)
             
             ScrollView {
                 TextFieldView(fieldName: "Nombre de Usuario", fieldValue: $viewModel.username)
                     //.padding(.top)
                 ValidationView(
-                    formText: "Son necesarios al menos 6 caracteres",
+                    formText: "Al menos 6 caracteres",
                     conditionChecked: $viewModel.isValidUsername)
 
                 HStack {
                     VStack{
                         TextFieldView(fieldName: "Contraseña", fieldValue: $viewModel.password, isSecure: true)
                         ValidationView(
-                            formText: "8+ caracteres",
+                            formText: "8 caracteres",
                             conditionChecked: $viewModel.isValidPasswordLength)
                         ValidationView(
-                            formText: "1+ mayúscula",
+                            formText: "1 mayúscula",
                             conditionChecked: $viewModel.isValidPasswordUpperCaseLetter)
                         ValidationView(
-                            formText: "1+ minúscula",
+                            formText: "1 minúscula",
                             conditionChecked: $viewModel.isValidPasswordLowerCaseLetter)
                         Spacer()
                     }
                     VStack {
                         TextFieldView(fieldName: "Repetir", fieldValue: $viewModel.passwordAgain, isSecure: true)
                         ValidationView(
-                            formText: "Deben coincidir",
+                            formText: "Son distintos",
                             conditionChecked: $viewModel.areMatchingPasswords)
                         Spacer()
                     }

--- a/combineSignUp/combineSignUp/Source/ViewModel/SignUpViewModel.swift
+++ b/combineSignUp/combineSignUp/Source/ViewModel/SignUpViewModel.swift
@@ -20,7 +20,23 @@ class SignUpViewModel: ObservableObject{ // Needs to conform ObservableObject to
     @Published var isValidPasswordCapitalLetter = false
     @Published var areMatchingPasswords = false
     
+    private let maxUserName: Int = 6
+    
     init() {
         // TODO: validation logic
+        // All SwiftUI controls can be subscribers, so a Text can listen to changes and updates its style itself
+        
+        // When ViewModel starts, must listen the username var and recieve events on main (because are visual changes)
+        // and each time a change are received will be transformed (with .map) to a boolean value thats indicates
+        // if is valid or not. Finally this transformation must be assiged to its corresponding bool var on its own class
+        
+        $username
+            .receive(on: RunLoop.main)                      // the suscriber receive changes
+            .map{ username in                               // make the necessary transformations
+                return username.count >= self.maxUserName   // and return the result value on a data type expected
+        }
+        .assign(to: \.isValidUsername, on: self)            // assignit to the corresponding var that will be published
+        // TODO: store
+        
     }
 }

--- a/combineSignUp/combineSignUp/Source/ViewModel/SignUpViewModel.swift
+++ b/combineSignUp/combineSignUp/Source/ViewModel/SignUpViewModel.swift
@@ -17,11 +17,13 @@ class SignUpViewModel: ObservableObject{ // Needs to conform ObservableObject to
     // Form validation
     @Published var isValidUsername = false
     @Published var isValidPasswordLength = false
-    @Published var isValidPasswordCapitalLetter = false
+    @Published var isValidPasswordUpperCaseLetter = false
+    @Published var isValidPasswordLowerCaseLetter = false
     @Published var areMatchingPasswords = false
     
-    private let maxUserName: Int = 6
-    
+    private let minUsername: Int = 6
+    private let minPassword: Int = 8
+
     init() {
         // TODO: validation logic
         // All SwiftUI controls can be subscribers, so a Text can listen to changes and updates its style itself
@@ -31,12 +33,50 @@ class SignUpViewModel: ObservableObject{ // Needs to conform ObservableObject to
         // if is valid or not. Finally this transformation must be assiged to its corresponding bool var on its own class
         
         $username
-            .receive(on: RunLoop.main)                      // the suscriber receive changes
-            .map{ username in                               // make the necessary transformations
-                return username.count >= self.maxUserName   // and return the result value on a data type expected
+            .receive(on: RunLoop.main)                    // the suscriber receive changes
+            .map{ username in                             // make the necessary transformations
+                return username.count >= self.minUsername // and return the result value on a data type expected
         }
-        .assign(to: \.isValidUsername, on: self)            // assignit to the corresponding var that will be published
-        // TODO: store
+        .assign(to: \.isValidUsername, on: self)          // assign it to the corresponding var that will be published
+        //TODO: store
+
+        // Password minimum lenght
+        $password
+            .receive(on: RunLoop.main)
+            .map{ password in
+                return password.count >= self.minPassword
+        }
+        .assign(to: \.isValidPasswordLength, on: self)
+        //TODO: store
+
+        // Password Upper case
+        $password
+            .receive(on: RunLoop.main)
+            .map{ password in
+                let regExPattern = "[A-Z]" // RegEx with Uppercased char
+                if let _ = password.range(of: regExPattern, options: .regularExpression) {
+                    return true
+                } else {
+                    return false
+                }
+        }
+        .assign(to: \.isValidPasswordUpperCaseLetter, on: self)
+        //TODO: store
+
+        // Password Upper case
+        $password
+            .receive(on: RunLoop.main)
+            .map{ password in
+                let regExPattern = "[a-z]" // RegEx with Lowercased char
+                if let _ = password.range(of: regExPattern, options: .regularExpression) {
+                    return true
+                } else {
+                    return false
+                }
+        }
+        .assign(to: \.isValidPasswordLowerCaseLetter, on: self)
+        //TODO: store
         
+        //TODO: Combine the two password published vars
     }
 }

--- a/combineSignUp/combineSignUp/Source/ViewModel/SignUpViewModel.swift
+++ b/combineSignUp/combineSignUp/Source/ViewModel/SignUpViewModel.swift
@@ -1,0 +1,26 @@
+//  SignUpViewModel.swift
+//  combineSignUp
+//
+//  Created by Simón Aparicio on 29/03/2020.
+//  Copyright © 2020 iPon.es. All rights reserved.
+//
+
+import Foundation
+
+class SignUpViewModel: ObservableObject{ // Needs to conform ObservableObject to use @Published
+    
+    // Form user entries
+    @Published var username = ""
+    @Published var password = ""
+    @Published var passwordAgain = ""
+    
+    // Form validation
+    @Published var isValidUsername = false
+    @Published var isValidPasswordLength = false
+    @Published var isValidPasswordCapitalLetter = false
+    @Published var areMatchingPasswords = false
+    
+    init() {
+        // TODO: validation logic
+    }
+}


### PR DESCRIPTION
### MVVM is ready and working with Combine framework!

The **View** now is using:
- [x] An `@ObservedObject` instead `@State`
- [x] A ViewModel instance where do all the necessary logic to validations:
`@ObservedObject private var viewModel = SignUpViewModel()`

The **ViewModel** is using:
- [x] `@Published` vars
- [x] `.range(of:options:)` with a RegEx pattern
- [x] A class that conforms `: ObservableObject` protocol
- [x] Doing all the magic in the `init()`, ViewModel is a `class`
1. `.receive(on:)` for the suscriber receive change, on main for visual changes 
2. `.map{ username in }` to make the necessary transformations in data
3. `.assign(to:)` assign it to the corresponding var that will be published
4. `.store(in:)`store the @Published reference in the `cancellableObjects: Set<AnyCancellable>` (needs Combine import)

